### PR TITLE
Fixed documentation missing from build output nuget package

### DIFF
--- a/Kajabity.Tools.Java/Kajabity.Tools.Java.csproj
+++ b/Kajabity.Tools.Java/Kajabity.Tools.Java.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net20;netstandard1.0;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.1;netstandard1.0;net40;net20</TargetFrameworks>
     <!-- Assembly info properties -->
     <AssemblyName>Kajabity.Tools.Java</AssemblyName>
     <AssemblyTitle>$(AssemblyName)</AssemblyTitle>
@@ -36,6 +36,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Kajabity.Tools</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
+    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
In my previous PR, while migrating the project to the new .NET.Sdk, I seem to have broken I by accident one of the beloved features of the library - namely it being wonderfully documented. This PR will restore the generation of the Kajabity.Tools.Java.xml into the build output, allowing it to be included the nuget package for future builds.